### PR TITLE
Fix schema relation and typing

### DIFF
--- a/fever-next/app/feeds/page.tsx
+++ b/fever-next/app/feeds/page.tsx
@@ -1,8 +1,16 @@
 import { PrismaClient } from '@prisma/client';
 
+interface FeedRecord {
+  id: number;
+  url: string;
+  title: string | null;
+  groupId: number | null;
+  siteUrl: string | null;
+}
+
 export const dynamic = 'force-dynamic';
 
-async function getFeeds() {
+async function getFeeds(): Promise<FeedRecord[]> {
   const prisma = new PrismaClient();
   const feeds = await prisma.feed.findMany({ include: { group: true } });
   await prisma.$disconnect();
@@ -15,7 +23,7 @@ export default async function FeedListPage() {
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Feeds</h1>
       <ul className="space-y-2">
-        {feeds.map((feed) => (
+        {feeds.map((feed: FeedRecord) => (
           <li key={feed.id} className="border p-2 rounded">
             {feed.title || feed.url}
           </li>

--- a/fever-next/prisma/schema.prisma
+++ b/fever-next/prisma/schema.prisma
@@ -31,6 +31,8 @@ model Feed {
   siteUrl  String?
   group    Group? @relation(fields: [groupId], references: [id])
   groupId  Int?
+  user     User?  @relation(fields: [userId], references: [id])
+  userId   Int?
   items    Item[]
   createdAt DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- fix missing relation in Prisma schema
- add explicit interface for Feed records
- annotate `getFeeds` and map callback with the interface to satisfy TypeScript

## Testing
- `./node_modules/.bin/tsc --noEmit`
- `npx prisma validate --skip-download` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683c390d51ec832d9c6b795c40222748