### PR TITLE
Add login page and OPML import/export API

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,5 +7,5 @@
 - [x] Set up NextAuth authentication
 - [x] Connect UI to API
 - [x] Schedule periodic feed refresh
-- [ ] Build login page
-- [ ] Add OPML import/export
+- [x] Build login page
+- [x] Add OPML import/export

--- a/fever-next/.gitignore
+++ b/fever-next/.gitignore
@@ -42,4 +42,8 @@ next-env.d.ts
 
 /app/generated/prisma
 
+# prisma local database files
+prisma/dev.db
+prisma/dev.db-journal
+
 pnpm-lock.yaml

--- a/fever-next/app/api/opml/route.ts
+++ b/fever-next/app/api/opml/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function GET() {
+  const feeds = await prisma.feed.findMany()
+  const outlines = feeds
+    .map(
+      (f) => `    <outline text="${f.title ?? f.url}" xmlUrl="${f.url}" />`
+    )
+    .join('\n')
+  const body = `<?xml version="1.0" encoding="UTF-8"?>\n<opml version="1.0">\n  <head>\n    <title>Fever Feeds</title>\n  </head>\n  <body>\n${outlines}\n  </body>\n</opml>`
+  return new NextResponse(body, {
+    headers: { 'Content-Type': 'application/xml' },
+  })
+}
+
+export async function POST(req: Request) {
+  const text = await req.text()
+  const urls = Array.from(text.matchAll(/xmlUrl="([^"]+)"/g)).map((m) => m[1])
+  for (const url of urls) {
+    await prisma.feed.upsert({
+      where: { url },
+      update: {},
+      create: { url },
+    })
+  }
+  return NextResponse.json({ imported: urls.length })
+}

--- a/fever-next/app/login/page.tsx
+++ b/fever-next/app/login/page.tsx
@@ -1,0 +1,40 @@
+'use client'
+import { signIn } from 'next-auth/react'
+import { useState } from 'react'
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    await signIn('credentials', { email, password, callbackUrl: '/feeds' })
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <h1 className="text-2xl font-bold text-center">Login</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full border p-2 rounded"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full border p-2 rounded"
+          required
+        />
+        <button type="submit" className="w-full bg-blue-500 text-white p-2 rounded">
+          Sign in
+        </button>
+      </form>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a basic login page using NextAuth
- expose OPML import/export API
- ignore prisma dev database files
- update TODO items

## Testing
- `pnpm run build` *(fails: connect EHOSTUNREACH 172.21.0.3:8080)*

------
https://chatgpt.com/codex/tasks/task_e_683c3f9f05a0832d96d3804b79958bbf