### PR TITLE
Add group and capability routes

### DIFF
--- a/fever-next/app/api/capabilities/route.ts
+++ b/fever-next/app/api/capabilities/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import nextPkg from 'next/package.json' assert { type: 'json' }
+import pkg from '../../../package.json' assert { type: 'json' }
+
+export async function GET() {
+  const capabilities = {
+    fever_version: pkg.version,
+    node_version: process.versions.node,
+    next_version: nextPkg.version,
+    has_prisma: Boolean(pkg.dependencies['@prisma/client']),
+    has_next_auth: Boolean(pkg.dependencies['next-auth']),
+    has_rss_parser: Boolean(pkg.dependencies['rss-parser']),
+    has_node_cron: Boolean(pkg.dependencies['node-cron']),
+  }
+  return NextResponse.json(capabilities)
+}

--- a/fever-next/app/api/groups/route.ts
+++ b/fever-next/app/api/groups/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function GET() {
+  const groups = await prisma.group.findMany()
+  return NextResponse.json(groups)
+}
+
+export async function POST(req: Request) {
+  const data = await req.json()
+  const group = await prisma.group.create({ data })
+  return NextResponse.json(group)
+}

--- a/fever-next/app/groups/page.tsx
+++ b/fever-next/app/groups/page.tsx
@@ -1,0 +1,26 @@
+import { PrismaClient } from '@prisma/client'
+
+export const dynamic = 'force-dynamic'
+
+async function getGroups() {
+  const prisma = new PrismaClient()
+  const groups = await prisma.group.findMany()
+  await prisma.$disconnect()
+  return groups
+}
+
+export default async function GroupListPage() {
+  const groups = await getGroups()
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Groups</h1>
+      <ul className="space-y-2">
+        {groups.map((group) => (
+          <li key={group.id} className="border p-2 rounded">
+            {group.name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/migration.md
+++ b/migration.md
@@ -35,9 +35,12 @@ This document summarizes the features and capabilities found in both the origina
   - `/api/items` – list feed items
   - `/api/opml` – import/export OPML
   - `/api/auth/[...nextauth]` – authentication
+  - `/api/groups` – list and create groups
+  - `/api/capabilities` – environment capabilities
 - React pages
   - `/login` – sign‑in form
   - `/feeds` – list of feeds
+  - `/groups` – list of groups
 - Feed fetching scripts (`scripts/fetchFeeds.ts`, `scripts/refreshFeeds.ts`)
 - Application layout with font loading and session provider
 - ESLint configuration and Next.js tooling
@@ -47,8 +50,9 @@ This document summarizes the features and capabilities found in both the origina
 - [ ] Database schema parity with legacy MySQL
 - [ ] Full installer/upgrade flow
  - [x] Reader interface with keyboard shortcuts
-- [ ] Favicon caching and image proxy
+ - [ ] Favicon caching and image proxy
  - [x] Item state management (read)
  - [x] Cron‑based refresh and background jobs
-- [ ] PHP API compatibility layer
+ - [x] Group management API
+ - [ ] PHP API compatibility layer
 


### PR DESCRIPTION
## Summary
- implement `/api/capabilities` for environment info
- add group management API and page
- track new features in `migration.md`

## Testing
- `pnpm run lint` *(fails: many ESLint errors)*
- `pnpm run build` *(fails: failed to fetch fonts, EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683c5a33837c832d9e99fe2c0d0cfdc3