### PR TITLE
Add Vercel cron job for feed refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ The original Fever PHP application is preserved in the `firewall/` directory. To
 - Write tests for new functionality
 - Document API changes and breaking changes
 
+### Scheduled Feed Refresh
+
+Vercel Cron Jobs automatically call `/api/cron` every ten minutes to update feeds. Set `CRON_SECRET` in your environment and configure the job in `vercel.json`.
+
+```
+{
+  "crons": [{
+    "path": "/api/cron",
+    "schedule": "*/10 * * * *"
+  }]
+}
+```
+
+Your cron endpoint checks the `Authorization` header against `CRON_SECRET` to prevent unauthorized requests.
+
+
 ## 📖 Documentation
 
 - [`boot-up.md`](./boot-up.md) - Initial setup instructions for Next.js

--- a/fever-next/.env.example
+++ b/fever-next/.env.example
@@ -1,3 +1,4 @@
 # Example environment variables for Fever Next.js
 DATABASE_URL="file:./dev.db"
 NEXTAUTH_SECRET="supersecret"
+CRON_SECRET=""

--- a/fever-next/app/api/cron/route.ts
+++ b/fever-next/app/api/cron/route.ts
@@ -1,0 +1,17 @@
+import type { NextRequest } from 'next/server';
+import { fetchFeeds } from '@/scripts/fetchFeeds';
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  try {
+    await fetchFeeds();
+    return Response.json({ success: true });
+  } catch (err) {
+    console.error('Cron job failed:', err);
+    return new Response('Internal Server Error', { status: 500 });
+  }
+}

--- a/fever-next/vercel.json
+++ b/fever-next/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron",
+      "schedule": "*/10 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- implement API route `/api/cron` secured with `CRON_SECRET`
- schedule cron job in `vercel.json`
- document cron configuration in README
- add `CRON_SECRET` to `.env.example`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build` *(fails: build attempted network access for fonts)*

------
https://chatgpt.com/codex/tasks/task_e_683c6c62cd84832db655e9dbda62b21c