### PR TITLE
Implement partial plan features

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ Vercel Cron Jobs automatically call `/api/cron` every ten minutes to update feed
 
 Your cron endpoint checks the `Authorization` header against `CRON_SECRET` to prevent unauthorized requests.
 
+### Update and Maintenance
+
+The legacy `update.php` script has been replaced by a Node-based helper. Run the
+following command inside the `fever-next` directory to manually refresh feeds or
+integrate with your own scheduler:
+
+```bash
+npm run cron
+```
+
+This command executes `scripts/cronRefresh.ts`, which in turn periodically
+invokes `scripts/fetchFeeds.ts` to update feed items in the database.
+
 
 ## 📖 Documentation
 


### PR DESCRIPTION
## Summary
- support marking feeds or groups read/unread via `/api/fever`
- document new cron update script in README

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*
- `npm run build` *(fails: network error fetching fonts)*

------
https://chatgpt.com/codex/tasks/task_e_683d1e983ff8832da3bc33c2665941ff