### PR TITLE
Implement feedlet bookmarklet and mobile reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ npm run cron
 This command executes `scripts/cronRefresh.ts`, which in turn periodically
 invokes `scripts/fetchFeeds.ts` to update feed items in the database.
 
+### Bookmarklet
+
+Use the [Feedlet bookmarklet](/feedlet) to quickly subscribe to the page you are
+viewing. Drag the "Subscribe with Fever" link from that page to your bookmarks
+bar and click it whenever you want to add a new feed.
+
+### Mobile Interface
+
+The simplified mobile reader is available at `/mobile` and is optimized for
+smaller screens.
+
 
 ## 📖 Documentation
 

--- a/fever-next/app/api/bookmarklet/route.ts
+++ b/fever-next/app/api/bookmarklet/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const feedUrl = url.searchParams.get('url')
+  if (!feedUrl) {
+    return new NextResponse('Missing url parameter', { status: 400 })
+  }
+  const existing = await prisma.feed.findUnique({ where: { url: feedUrl } })
+  if (!existing) {
+    await prisma.feed.create({ data: { url: feedUrl } })
+  }
+  const html = `<!doctype html><html><body><p>Feed added. You can close this window.</p></body></html>`
+  return new NextResponse(html, { headers: { 'Content-Type': 'text/html' } })
+}

--- a/fever-next/app/feedlet/page.tsx
+++ b/fever-next/app/feedlet/page.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+export default function FeedletPage() {
+  const bookmarklet = `javascript:(function(){window.open(window.location.origin+'/api/bookmarklet?url='+encodeURIComponent(location.href));})();`
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Feedlet Bookmarklet</h1>
+      <p>Drag the link below to your bookmarks bar:</p>
+      <a className="text-blue-600 underline" href={bookmarklet}>Subscribe with Fever</a>
+    </div>
+  )
+}

--- a/fever-next/app/mobile/page.tsx
+++ b/fever-next/app/mobile/page.tsx
@@ -1,0 +1,31 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+interface Item {
+  id: number
+  title: string
+  link: string
+  content: string | null
+}
+
+export default function MobilePage() {
+  const [items, setItems] = useState<Item[]>([])
+
+  useEffect(() => {
+    fetch('/api/items?feedId=1')
+      .then(res => res.json())
+      .then(data => setItems(data))
+  }, [])
+
+  return (
+    <div className="p-2 space-y-4 text-sm">
+      {items.map(item => (
+        <article key={item.id} className="border-b pb-2">
+          <a href={item.link} className="font-semibold" target="_blank" rel="noopener noreferrer">
+            {item.title}
+          </a>
+        </article>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a `feedlet` bookmarklet page
- create `/api/bookmarklet` endpoint to add feeds
- add a simple mobile reader interface
- mention bookmarklet and mobile interface in README

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build` *(fails: unable to fetch fonts during build)*

------
https://chatgpt.com/codex/tasks/task_e_683d261a7768832d8068c48da190cef0