### PR TITLE
Implement upkeep scripts and improved bookmarklet

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,22 +154,41 @@ Your cron endpoint checks the `Authorization` header against `CRON_SECRET` to pr
 
 ### Update and Maintenance
 
-The legacy `update.php` script has been replaced by a Node-based helper. Run the
-following command inside the `fever-next` directory to manually refresh feeds or
-integrate with your own scheduler:
+The legacy `update.php` script has been replaced by Node helpers. Use the
+following commands inside the `fever-next` directory:
 
 ```bash
-npm run cron
+npm run refresh   # fetch feeds once
+npm run cron      # run the scheduled refresher
+npm run prune     # remove old items and empty feeds
 ```
 
-This command executes `scripts/cronRefresh.ts`, which in turn periodically
-invokes `scripts/fetchFeeds.ts` to update feed items in the database.
+`npm run cron` executes `scripts/cronRefresh.ts`, which periodically invokes
+`scripts/fetchFeeds.ts` to update feed items in the database. `npm run prune`
+deletes items older than 30 days and any feeds that no longer contain items.
+
+### Upgrade Workflow
+
+When updating to a new version of Fever Next:
+
+1. `git pull` to fetch the latest code
+2. `npm install` to update dependencies
+3. `npm run install-db` to apply database migrations
+4. Optionally `npm run refresh` to fetch feeds immediately
 
 ### Bookmarklet
 
 Use the [Feedlet bookmarklet](/feedlet) to quickly subscribe to the page you are
-viewing. Drag the "Subscribe with Fever" link from that page to your bookmarks
-bar and click it whenever you want to add a new feed.
+viewing. Drag the **"Subscribe with Fever"** link from that page to your
+bookmarks bar.
+
+**Chrome & Firefox**: drag the link directly to the bookmarks bar.
+
+**Safari**: right‑click the link, choose *Add Bookmark*, then edit the location
+to your bookmarks bar.
+
+When you click the bookmarklet, a small window opens confirming whether the feed
+was added successfully or already subscribed.
 
 ### Mobile Interface
 

--- a/fever-next/app/api/bookmarklet/route.ts
+++ b/fever-next/app/api/bookmarklet/route.ts
@@ -10,9 +10,12 @@ export async function GET(req: Request) {
     return new NextResponse('Missing url parameter', { status: 400 })
   }
   const existing = await prisma.feed.findUnique({ where: { url: feedUrl } })
-  if (!existing) {
+  let message = 'Feed added successfully.'
+  if (existing) {
+    message = 'Feed already subscribed.'
+  } else {
     await prisma.feed.create({ data: { url: feedUrl } })
   }
-  const html = `<!doctype html><html><body><p>Feed added. You can close this window.</p></body></html>`
+  const html = `<!doctype html><html><body><p>${message} You can close this window.</p></body></html>`
   return new NextResponse(html, { headers: { 'Content-Type': 'text/html' } })
 }

--- a/fever-next/package.json
+++ b/fever-next/package.json
@@ -8,6 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "cron": "node ./scripts/cronRefresh.ts",
+    "refresh": "node ./scripts/fetchFeeds.ts",
+    "prune": "node ./scripts/pruneOld.ts",
     "install-db": "node ./scripts/install.js"
   },
   "dependencies": {

--- a/fever-next/scripts/pruneOld.ts
+++ b/fever-next/scripts/pruneOld.ts
@@ -1,0 +1,25 @@
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+async function prune() {
+  const cutoff = new Date()
+  cutoff.setDate(cutoff.getDate() - 30)
+
+  await prisma.item.deleteMany({
+    where: { createdAt: { lt: cutoff } },
+  })
+
+  await prisma.feed.deleteMany({
+    where: {
+      createdAt: { lt: cutoff },
+      items: { none: {} },
+    },
+  })
+}
+
+prune().catch(err => {
+  console.error('Prune failed', err)
+  process.exit(1)
+}).finally(() => prisma.$disconnect())
+


### PR DESCRIPTION
## Summary
- add manual refresh and prune scripts to package.json
- improve success messages for the bookmarklet API
- document maintenance tasks and bookmarklet install steps
- add `pruneOld.ts` helper script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683d2a2610f8832d929b8aad6c79fcfd