### PR TITLE
Implement core Next.js management UI

### DIFF
--- a/fever-next/app/api/feeds/[id]/route.ts
+++ b/fever-next/app/api/feeds/[id]/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const data = await req.json()
+  const feed = await prisma.feed.update({ where: { id: Number(params.id) }, data })
+  return NextResponse.json(feed)
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  await prisma.feed.delete({ where: { id: Number(params.id) } })
+  return NextResponse.json({ success: true })
+}

--- a/fever-next/app/api/groups/[id]/route.ts
+++ b/fever-next/app/api/groups/[id]/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const data = await req.json()
+  const group = await prisma.group.update({ where: { id: Number(params.id) }, data })
+  return NextResponse.json(group)
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  await prisma.group.delete({ where: { id: Number(params.id) } })
+  return NextResponse.json({ success: true })
+}

--- a/fever-next/app/api/install/route.ts
+++ b/fever-next/app/api/install/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function GET() {
+  const user = await prisma.user.findFirst()
+  return NextResponse.json({ installed: Boolean(user) })
+}
+
+export async function POST(req: Request) {
+  const { email, password } = await req.json()
+  if (!email || !password) {
+    return NextResponse.json({ error: 'Email and password required' }, { status: 400 })
+  }
+  const existing = await prisma.user.findFirst()
+  if (existing) {
+    return NextResponse.json({ error: 'Already installed' }, { status: 400 })
+  }
+  await prisma.user.create({ data: { email, password } })
+  return NextResponse.json({ success: true })
+}

--- a/fever-next/app/api/user/password/route.ts
+++ b/fever-next/app/api/user/password/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function POST(req: Request) {
+  const { password } = await req.json()
+  if (!password) {
+    return NextResponse.json({ error: 'Password required' }, { status: 400 })
+  }
+  const user = await prisma.user.findFirst()
+  if (!user) {
+    return NextResponse.json({ error: 'No user found' }, { status: 400 })
+  }
+  await prisma.user.update({ where: { id: user.id }, data: { password } })
+  return NextResponse.json({ success: true })
+}

--- a/fever-next/app/feeds/page.tsx
+++ b/fever-next/app/feeds/page.tsx
@@ -1,34 +1,59 @@
-import { PrismaClient } from '@prisma/client';
+'use client'
+import { useEffect, useState } from 'react'
 
-interface FeedRecord {
-  id: number;
-  url: string;
-  title: string | null;
-  groupId: number | null;
-  siteUrl: string | null;
-}
+interface Feed { id: number; url: string; title?: string | null; groupId?: number | null }
+interface Group { id: number; name: string }
 
-export const dynamic = 'force-dynamic';
+export default function FeedListPage() {
+  const [feeds, setFeeds] = useState<Feed[]>([])
+  const [groups, setGroups] = useState<Group[]>([])
+  const [url, setUrl] = useState('')
+  const [groupId, setGroupId] = useState<number | ''>('' as any)
 
-async function getFeeds(): Promise<FeedRecord[]> {
-  const prisma = new PrismaClient();
-  const feeds = await prisma.feed.findMany({ include: { group: true } });
-  await prisma.$disconnect();
-  return feeds;
-}
+  useEffect(() => {
+    fetch('/api/feeds').then(res => res.json()).then(setFeeds)
+    fetch('/api/groups').then(res => res.json()).then(setGroups)
+  }, [])
 
-export default async function FeedListPage() {
-  const feeds = await getFeeds();
+  async function addFeed(e: React.FormEvent) {
+    e.preventDefault()
+    const res = await fetch('/api/feeds', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url, groupId: groupId || null })
+    })
+    if (res.ok) {
+      const feed = await res.json()
+      setFeeds([...feeds, feed])
+      setUrl('')
+      setGroupId('' as any)
+    }
+  }
+
+  async function remove(id: number) {
+    await fetch(`/api/feeds/${id}`, { method: 'DELETE' })
+    setFeeds(feeds.filter(f => f.id !== id))
+  }
+
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Feeds</h1>
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Feeds</h1>
+      <form onSubmit={addFeed} className="space-x-2">
+        <input value={url} onChange={e => setUrl(e.target.value)} className="border p-1 rounded" placeholder="Feed URL" required />
+        <select value={groupId} onChange={e => setGroupId(e.target.value ? Number(e.target.value) : '' as any)} className="border p-1 rounded">
+          <option value="">No group</option>
+          {groups.map(g => (<option key={g.id} value={g.id}>{g.name}</option>))}
+        </select>
+        <button type="submit" className="border px-2 py-1 rounded">Add</button>
+      </form>
       <ul className="space-y-2">
-        {feeds.map((feed: FeedRecord) => (
-          <li key={feed.id} className="border p-2 rounded">
-            {feed.title || feed.url}
+        {feeds.map(feed => (
+          <li key={feed.id} className="border p-2 rounded flex justify-between">
+            <span>{feed.title || feed.url}</span>
+            <button onClick={() => remove(feed.id)} className="text-red-600">Delete</button>
           </li>
         ))}
       </ul>
     </div>
-  );
+  )
 }

--- a/fever-next/app/groups/page.tsx
+++ b/fever-next/app/groups/page.tsx
@@ -1,23 +1,49 @@
-import { PrismaClient } from '@prisma/client'
+'use client'
+import { useEffect, useState } from 'react'
 
-export const dynamic = 'force-dynamic'
+interface Group { id: number; name: string }
 
-async function getGroups() {
-  const prisma = new PrismaClient()
-  const groups = await prisma.group.findMany()
-  await prisma.$disconnect()
-  return groups
-}
+export default function GroupListPage() {
+  const [groups, setGroups] = useState<Group[]>([])
+  const [name, setName] = useState('')
 
-export default async function GroupListPage() {
-  const groups = await getGroups()
+  useEffect(() => {
+    fetch('/api/groups')
+      .then(res => res.json())
+      .then(setGroups)
+  }, [])
+
+  async function addGroup(e: React.FormEvent) {
+    e.preventDefault()
+    const res = await fetch('/api/groups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name })
+    })
+    if (res.ok) {
+      const group = await res.json()
+      setGroups([...groups, group])
+      setName('')
+    }
+  }
+
+  async function remove(id: number) {
+    await fetch(`/api/groups/${id}`, { method: 'DELETE' })
+    setGroups(groups.filter(g => g.id !== id))
+  }
+
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Groups</h1>
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Groups</h1>
+      <form onSubmit={addGroup} className="space-x-2">
+        <input value={name} onChange={e => setName(e.target.value)} className="border p-1 rounded" placeholder="Group name" required />
+        <button type="submit" className="border px-2 py-1 rounded">Add</button>
+      </form>
       <ul className="space-y-2">
-        {groups.map((group) => (
-          <li key={group.id} className="border p-2 rounded">
-            {group.name}
+        {groups.map(group => (
+          <li key={group.id} className="border p-2 rounded flex justify-between">
+            <span>{group.name}</span>
+            <button onClick={() => remove(group.id)} className="text-red-600">Delete</button>
           </li>
         ))}
       </ul>

--- a/fever-next/app/import-export/page.tsx
+++ b/fever-next/app/import-export/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+import { useState } from 'react'
+
+export default function ImportExportPage() {
+  const [file, setFile] = useState<File | null>(null)
+  const [message, setMessage] = useState('')
+
+  async function handleImport(e: React.FormEvent) {
+    e.preventDefault()
+    if (!file) return
+    const text = await file.text()
+    const res = await fetch('/api/opml', { method: 'POST', body: text })
+    if (res.ok) {
+      const data = await res.json()
+      setMessage(`Imported ${data.imported} feeds`)
+    } else {
+      setMessage('Import failed')
+    }
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Import / Export</h1>
+      <a href="/api/opml" className="underline text-blue-600">Download OPML</a>
+      <form onSubmit={handleImport} className="space-y-2">
+        <input type="file" accept="text/xml" onChange={e => setFile(e.target.files?.[0] || null)} />
+        <button type="submit" className="border px-2 py-1 rounded">Import</button>
+      </form>
+      {message && <p>{message}</p>}
+    </div>
+  )
+}

--- a/fever-next/app/install/page.tsx
+++ b/fever-next/app/install/page.tsx
@@ -1,0 +1,61 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function InstallPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    fetch('/api/install')
+      .then(res => res.json())
+      .then(data => {
+        if (data.installed) router.replace('/login')
+      })
+  }, [router])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const res = await fetch('/api/install', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    })
+    if (res.ok) {
+      router.push('/login')
+    } else {
+      const data = await res.json()
+      setError(data.error || 'Install failed')
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <h1 className="text-2xl font-bold text-center">Install Fever</h1>
+        {error && <p className="text-red-500">{error}</p>}
+        <input
+          type="email"
+          placeholder="Admin email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          className="w-full border p-2 rounded"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          className="w-full border p-2 rounded"
+          required
+        />
+        <button type="submit" className="w-full bg-blue-500 text-white p-2 rounded">
+          Install
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/fever-next/app/settings/page.tsx
+++ b/fever-next/app/settings/page.tsx
@@ -5,6 +5,8 @@ import { LayoutContext } from '../providers'
 export default function SettingsPage() {
   const { layout, setLayout } = useContext(LayoutContext)
   const [current, setCurrent] = useState<'mobile' | 'desktop'>(layout)
+  const [password, setPassword] = useState('')
+  const [message, setMessage] = useState('')
 
   useEffect(() => {
     setCurrent(layout)
@@ -14,6 +16,22 @@ export default function SettingsPage() {
     const next = current === 'desktop' ? 'mobile' : 'desktop'
     setCurrent(next)
     setLayout(next)
+  }
+
+  async function changePassword(e: React.FormEvent) {
+    e.preventDefault()
+    const res = await fetch('/api/user/password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password })
+    })
+    if (res.ok) {
+      setMessage('Password updated')
+      setPassword('')
+    } else {
+      const data = await res.json()
+      setMessage(data.error || 'Error')
+    }
   }
 
   return (
@@ -28,6 +46,17 @@ export default function SettingsPage() {
           {current === 'desktop' ? 'Switch to mobile' : 'Switch to desktop'}
         </button>
       </div>
+      <form onSubmit={changePassword} className="space-y-2">
+        <input
+          type="password"
+          placeholder="New password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          className="border p-2 rounded w-full"
+        />
+        <button type="submit" className="border px-2 py-1 rounded">Change Password</button>
+      </form>
+      {message && <p>{message}</p>}
     </div>
   )
 }

--- a/finalize-plan.md
+++ b/finalize-plan.md
@@ -10,10 +10,10 @@
 - [x] Cron refresh and fetch scripts
 - [x] Favicon caching
 - [x] Mobile reader with service worker
-- [ ] Installation wizard
-- [ ] Preferences page
-- [ ] Feed/group management UI
-- [ ] Import/export UI
+- [x] Installation wizard
+- [x] Preferences page
+- [x] Feed/group management UI
+- [x] Import/export UI
 - [x] Uninstall/reset script
 
 This document summarizes the legacy **Fever** PHP codebase and its views. Each section details the purpose of the files and the main functions exposed.


### PR DESCRIPTION
## Summary
- finish migration tasks in finalize-plan checklist
- add installation API and page
- support feed & group management
- implement import/export page
- allow users to change password via settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683d68a7af10832dbf00a84f725d4513