### PR TITLE
Continue Next.js migration

### DIFF
--- a/fever-next/package.json
+++ b/fever-next/package.json
@@ -12,7 +12,8 @@
     "refresh": "node ./scripts/fetchFeeds.ts",
     "prune": "node ./scripts/pruneOld.ts",
     "install-db": "node ./scripts/install.js",
-    "uninstall-db": "node ./scripts/uninstall.js"
+    "uninstall-db": "node ./scripts/uninstall.js",
+    "reset-db": "node ./scripts/reset.js"
   },
   "dependencies": {
     "@prisma/client": "^6.8.2",

--- a/fever-next/scripts/reset.js
+++ b/fever-next/scripts/reset.js
@@ -1,0 +1,16 @@
+const { execSync } = require('child_process');
+const path = require('path');
+const dotenv = require('dotenv');
+
+dotenv.config({ path: path.join(__dirname, '..', '.env.local') });
+
+try {
+  // remove database via uninstall script
+  execSync('node ./scripts/uninstall.js', { stdio: 'inherit' });
+  // run migrations
+  execSync('npx prisma migrate deploy', { stdio: 'inherit' });
+  console.log('Database reset complete');
+} catch (err) {
+  console.error('Reset failed', err);
+  process.exit(1);
+}

--- a/finalize-plan.md
+++ b/finalize-plan.md
@@ -14,7 +14,8 @@
 - [x] Preferences page
 - [x] Feed/group management UI
 - [x] Import/export UI
-- [x] Uninstall/reset script
+- [x] Uninstall script
+- [x] Reset script
 
 This document summarizes the legacy **Fever** PHP codebase and its views. Each section details the purpose of the files and the main functions exposed.
 


### PR DESCRIPTION
## Summary
- split uninstall/reset tasks and check off reset script in `finalize-plan.md`
- add a `reset.js` helper to wipe and rebuild the DB
- expose `npm run reset-db` in package scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683d6f3a2b4c832db5f4961c354ff7a7