### PR TITLE
Implement Hot and Kindling features

### DIFF
--- a/fever-next/app/api/feeds/[id]/route.ts
+++ b/fever-next/app/api/feeds/[id]/route.ts
@@ -5,7 +5,10 @@ const prisma = new PrismaClient()
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
   const data = await req.json()
-  const feed = await prisma.feed.update({ where: { id: Number(params.id) }, data })
+  const feed = await prisma.feed.update({
+    where: { id: Number(params.id) },
+    data,
+  })
   return NextResponse.json(feed)
 }
 

--- a/fever-next/app/api/feeds/route.ts
+++ b/fever-next/app/api/feeds/route.ts
@@ -10,6 +10,14 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const data = await req.json();
-  const feed = await prisma.feed.create({ data });
+  const feed = await prisma.feed.create({
+    data: {
+      url: data.url,
+      groupId: data.groupId,
+      title: data.title,
+      siteUrl: data.siteUrl,
+      isSpark: data.isSpark ?? false,
+    },
+  });
   return NextResponse.json(feed);
 }

--- a/fever-next/app/api/hot/route.ts
+++ b/fever-next/app/api/hot/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function GET() {
+  const items = await prisma.item.findMany({
+    where: { pubDate: { gte: new Date(Date.now() - 24 * 60 * 60 * 1000) } },
+    include: { feed: true },
+  })
+  const map = new Map<string, { title: string; link: string; weight: number }>()
+  for (const it of items) {
+    const key = it.link
+    const entry = map.get(key) || { title: it.title, link: it.link, weight: 0 }
+    entry.weight += it.feed.isSpark ? 0.5 : 1
+    map.set(key, entry)
+  }
+  const links = Array.from(map.values())
+    .sort((a, b) => b.weight - a.weight)
+    .slice(0, 20)
+    .map(l => ({
+      title: l.title,
+      link: l.link,
+      temperature: Number((98.6 + l.weight * 5).toFixed(1)),
+    }))
+  return NextResponse.json(links)
+}

--- a/fever-next/app/api/items/route.ts
+++ b/fever-next/app/api/items/route.ts
@@ -6,14 +6,22 @@ const prisma = new PrismaClient();
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const feedId = url.searchParams.get('feedId');
-  if (!feedId) {
+  const kindling = url.searchParams.get('kindling');
+
+  const where: any = {};
+  if (feedId) {
+    where.feedId = Number(feedId);
+  } else if (kindling === '1') {
+    where.feed = { isSpark: false };
+  } else {
     return NextResponse.json(
-      { error: 'feedId query param required' },
+      { error: 'feedId or kindling=1 query param required' },
       { status: 400 }
     );
   }
+
   const items = await prisma.item.findMany({
-    where: { feedId: Number(feedId) },
+    where,
     orderBy: { pubDate: 'desc' },
   });
   return NextResponse.json(items);

--- a/fever-next/app/feeds/page.tsx
+++ b/fever-next/app/feeds/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 
-interface Feed { id: number; url: string; title?: string | null; groupId?: number | null }
+interface Feed { id: number; url: string; title?: string | null; groupId?: number | null; isSpark?: boolean }
 interface Group { id: number; name: string }
 
 export default function FeedListPage() {
@@ -9,6 +9,7 @@ export default function FeedListPage() {
   const [groups, setGroups] = useState<Group[]>([])
   const [url, setUrl] = useState('')
   const [groupId, setGroupId] = useState<number | ''>('' as any)
+  const [isSpark, setIsSpark] = useState(false)
 
   useEffect(() => {
     fetch('/api/feeds').then(res => res.json()).then(setFeeds)
@@ -20,19 +21,32 @@ export default function FeedListPage() {
     const res = await fetch('/api/feeds', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ url, groupId: groupId || null })
+      body: JSON.stringify({ url, groupId: groupId || null, isSpark })
     })
     if (res.ok) {
       const feed = await res.json()
       setFeeds([...feeds, feed])
       setUrl('')
       setGroupId('' as any)
+      setIsSpark(false)
     }
   }
 
   async function remove(id: number) {
     await fetch(`/api/feeds/${id}`, { method: 'DELETE' })
     setFeeds(feeds.filter(f => f.id !== id))
+  }
+
+  async function toggleSpark(id: number, value: boolean) {
+    const res = await fetch(`/api/feeds/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isSpark: !value })
+    })
+    if (res.ok) {
+      const updated = await res.json()
+      setFeeds(feeds.map(f => (f.id === id ? updated : f)))
+    }
   }
 
   return (
@@ -44,13 +58,23 @@ export default function FeedListPage() {
           <option value="">No group</option>
           {groups.map(g => (<option key={g.id} value={g.id}>{g.name}</option>))}
         </select>
+        <label className="space-x-1">
+          <input type="checkbox" checked={isSpark} onChange={e => setIsSpark(e.target.checked)} />
+          <span>Spark</span>
+        </label>
         <button type="submit" className="border px-2 py-1 rounded">Add</button>
       </form>
       <ul className="space-y-2">
         {feeds.map(feed => (
-          <li key={feed.id} className="border p-2 rounded flex justify-between">
-            <span>{feed.title || feed.url}</span>
-            <button onClick={() => remove(feed.id)} className="text-red-600">Delete</button>
+          <li key={feed.id} className="border p-2 rounded flex justify-between items-center">
+            <span>
+              {feed.title || feed.url}
+              {feed.isSpark ? ' (Spark)' : ''}
+            </span>
+            <div className="space-x-2">
+              <button onClick={() => toggleSpark(feed.id, feed.isSpark ?? false)} className="text-blue-600">{feed.isSpark ? 'Unset Spark' : 'Set Spark'}</button>
+              <button onClick={() => remove(feed.id)} className="text-red-600">Delete</button>
+            </div>
           </li>
         ))}
       </ul>

--- a/fever-next/app/hot/page.tsx
+++ b/fever-next/app/hot/page.tsx
@@ -1,0 +1,30 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+interface HotLink {
+  title: string
+  link: string
+  temperature: number
+}
+
+export default function HotPage() {
+  const [links, setLinks] = useState<HotLink[]>([])
+
+  useEffect(() => {
+    fetch('/api/hot').then(res => res.json()).then(setLinks)
+  }, [])
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Hot Links</h1>
+      <ul className="space-y-2">
+        {links.map(l => (
+          <li key={l.link} className="border p-2 rounded">
+            <span className="font-bold mr-2">{l.temperature}&deg;</span>
+            <a href={l.link} className="underline" target="_blank" rel="noopener noreferrer">{l.title}</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/fever-next/app/kindling/page.tsx
+++ b/fever-next/app/kindling/page.tsx
@@ -1,0 +1,31 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+interface Item {
+  id: number
+  title: string
+  link: string
+  content: string | null
+}
+
+export default function KindlingPage() {
+  const [items, setItems] = useState<Item[]>([])
+
+  useEffect(() => {
+    fetch('/api/items?kindling=1').then(res => res.json()).then(setItems)
+  }, [])
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Kindling</h1>
+      {items.map(it => (
+        <article key={it.id} className="border p-2 rounded">
+          <h2 className="font-bold text-lg">
+            <a href={it.link} target="_blank" rel="noopener noreferrer">{it.title}</a>
+          </h2>
+          <div dangerouslySetInnerHTML={{ __html: it.content || '' }} />
+        </article>
+      ))}
+    </div>
+  )
+}

--- a/fever-next/prisma/schema.prisma
+++ b/fever-next/prisma/schema.prisma
@@ -32,6 +32,7 @@ model Feed {
   favicon  String?
   group    Group? @relation(fields: [groupId], references: [id])
   groupId  Int?
+  isSpark  Boolean @default(false)
   user     User?  @relation(fields: [userId], references: [id])
   userId   Int?
   items    Item[]


### PR DESCRIPTION
## Summary
- allow marking feeds as "Spark" in the UI
- store `isSpark` flag in Prisma schema
- support updating Spark status via API
- expose `/api/hot` to list trending links with temperatures
- add Hot and Kindling pages
- extend `/api/items` to serve Kindling items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68410235ea8c832d9ea185806abde92d